### PR TITLE
Ensure follower selection always reloads data

### DIFF
--- a/client/ui/follower_window.lua
+++ b/client/ui/follower_window.lua
@@ -228,11 +228,10 @@ function NS.FollowerWindow:SelectFollower(followerID)
   
   -- ИСПРАВЛЕНО: Всегда обновляем подсветку ПЕРВЫМ ДЕЛОМ
   self:UpdateFollowerButtonHighlight(followerID)
-  
-  -- Если тот же фолловер, пропускаем загрузку данных
+
+  -- Всегда загружаем данные, даже если выбран тот же фолловер
   if followerID == self.currentFollowerID then
-    NS.Logger:UI("Same follower, skipping data load")
-    return
+    NS.Logger:UI("Same follower selected again; reloading data")
   end
 
   -- ИСПРАВЛЕНО: Сохраняем выбор ТОЛЬКО здесь
@@ -422,8 +421,10 @@ function NS.FollowerWindow:Show(followerID)
   if not isTargetValid then
     target = unlocked[1]
   end
-  
-  if target then 
+
+  if target then
+    -- Сбрасываем текущий ID, чтобы запросить свежие данные даже при повторном выборе
+    self.currentFollowerID = nil
     self:SelectFollower(target)
   end
 end


### PR DESCRIPTION
## Summary
- Reset `currentFollowerID` before selecting a follower in `Show`
- Always reload data in `SelectFollower` even when selecting the same follower

## Testing
- `lua -p client/ui/follower_window.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c7b242248326ab955c277a24d82e