### PR TITLE
Include follower ID in speaker data and UI state

### DIFF
--- a/client/core/ui_manager.lua
+++ b/client/core/ui_manager.lua
@@ -359,7 +359,12 @@ end
 -- НОВОЕ: Современная обработка через события вместо прямых вызовов
 function PatronSystemNS.UIManager:OnSpeakerDataReceived(speakerData)
     PatronSystemNS.Logger:UI("Получены данные о говорящем: " .. (speakerData.Name or "Неизвестно"))
-    
+
+    -- Гарантируем наличие FollowerID в данных текущего говорящего
+    if speakerData.SpeakerType == PatronSystemNS.Config.SpeakerType.FOLLOWER then
+        speakerData.FollowerID = speakerData.FollowerID or speakerData.SpeakerID
+    end
+
     self.currentSpeaker = speakerData
     
     -- ИСПРАВЛЕНИЕ: Проверяем PatronWindow напрямую, игнорируем currentWindow

--- a/server/06_PatronSystem_Main.lua
+++ b/server/06_PatronSystem_Main.lua
@@ -404,6 +404,7 @@ local function HandleRequestFollowerData(player, requestData)
     local safeFollowerData = {
         SpeakerID = followerId,
         SpeakerType = "follower",
+        FollowerID = followerId,
         Name = followerInfo.FollowerName,
         PatronID = followerInfo.PatronID, -- К какому покровителю привязан
         Alignment = followerInfo.Aligment, -- используем орфографию из исходных данных


### PR DESCRIPTION
## Summary
- send explicit `FollowerID` in follower data responses
- propagate `FollowerID` into `UIManager.currentSpeaker`

## Testing
- `luac -p server/06_PatronSystem_Main.lua client/core/ui_manager.lua client/main.lua` *(fails: command not found)*
- `apt-get update` *(fails: 403 repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cd08081c8326ae3ec27cb369d302