### PR TITLE
Fix follower smalltalk ID comparison

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -185,14 +185,15 @@ local function RegisterAIOHandlers()
 
                         local cs = PatronSystemNS.UIManager.currentSpeaker
                         if cs and cs.SpeakerType == data.speakerType then
-                                local currentId = nil
+                                local currentId
+                                local eventId = tonumber(data.speakerId)
                                 if data.speakerType == PatronSystemNS.Config.SpeakerType.PATRON then
                                         currentId = cs.PatronID
                                 elseif data.speakerType == PatronSystemNS.Config.SpeakerType.FOLLOWER then
-                                        currentId = cs.FollowerID
+                                        currentId = tonumber(cs.FollowerID)
                                 end
 
-                                if currentId == data.speakerId then
+                                if currentId == eventId then
                                         cs.smallTalk = data.smallTalk
                                         cs.availableSmallTalks = data.availableSmallTalks
 


### PR DESCRIPTION
## Summary
- Cast `cs.FollowerID` and `data.speakerId` to numbers before comparing in `SmallTalkRefreshed`

## Testing
- `luac -p client/main.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed 403)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d6b8855c8326b78989c7965f7884