### PR TITLE
Route dialogue events by speaker type

### DIFF
--- a/client/core/ui_manager.lua
+++ b/client/core/ui_manager.lua
@@ -391,31 +391,45 @@ end
 
 function PatronSystemNS.UIManager:OnDialogueUpdated(dialogueData)
     PatronSystemNS.Logger:UI("Обновление диалога: " .. (dialogueData.text or "пустой"))
-    
-    -- Проверяем, какое окно открыто и передаем диалог в соответствующее
-    if PatronSystemNS.PatronWindow and PatronSystemNS.PatronWindow:IsShown() then
-        PatronSystemNS.Logger:UI("Передаем диалог в PatronWindow")
-        PatronSystemNS.PatronWindow:UpdateDialogue(dialogueData)
-    elseif PatronSystemNS.FollowerWindow and PatronSystemNS.FollowerWindow:IsShown() then
-        PatronSystemNS.Logger:UI("Передаем диалог в FollowerWindow")
-        PatronSystemNS.FollowerWindow:UpdateDialogue(dialogueData)
+
+    local speakerType = PatronSystemNS.DialogueEngine.currentSpeakerType
+
+    if speakerType == PatronSystemNS.Config.SpeakerType.FOLLOWER then
+        if PatronSystemNS.FollowerWindow and PatronSystemNS.FollowerWindow:IsShown() then
+            PatronSystemNS.Logger:UI("Передаем диалог в FollowerWindow")
+            PatronSystemNS.FollowerWindow:UpdateDialogue(dialogueData)
+        else
+            PatronSystemNS.Logger:Warn("FollowerWindow не открыт для отображения диалога")
+        end
     else
-        PatronSystemNS.Logger:Warn("Ни PatronWindow, ни FollowerWindow не открыты для отображения диалога")
+        if PatronSystemNS.PatronWindow and PatronSystemNS.PatronWindow:IsShown() then
+            PatronSystemNS.Logger:UI("Передаем диалог в PatronWindow")
+            PatronSystemNS.PatronWindow:UpdateDialogue(dialogueData)
+        else
+            PatronSystemNS.Logger:Warn("PatronWindow не открыт для отображения диалога")
+        end
     end
 end
 
 function PatronSystemNS.UIManager:OnDialogueEnded()
     PatronSystemNS.Logger:UI("Диалог завершен")
-    
-    -- Проверяем, какое окно открыто и уведомляем о завершении диалога
-    if PatronSystemNS.PatronWindow and PatronSystemNS.PatronWindow:IsShown() then
-        PatronSystemNS.Logger:UI("Уведомляем PatronWindow о завершении диалога")
-        PatronSystemNS.PatronWindow:OnDialogueEnded()
-    elseif PatronSystemNS.FollowerWindow and PatronSystemNS.FollowerWindow:IsShown() then
-        PatronSystemNS.Logger:UI("Уведомляем FollowerWindow о завершении диалога")
-        PatronSystemNS.FollowerWindow:OnDialogueEnded()
+
+    local speakerType = PatronSystemNS.DialogueEngine.currentSpeakerType
+
+    if speakerType == PatronSystemNS.Config.SpeakerType.FOLLOWER then
+        if PatronSystemNS.FollowerWindow and PatronSystemNS.FollowerWindow:IsShown() then
+            PatronSystemNS.Logger:UI("Уведомляем FollowerWindow о завершении диалога")
+            PatronSystemNS.FollowerWindow:OnDialogueEnded()
+        else
+            PatronSystemNS.Logger:UI("FollowerWindow не открыт для завершения диалога")
+        end
     else
-        PatronSystemNS.Logger:UI("Ни PatronWindow, ни FollowerWindow не открыты для завершения диалога")
+        if PatronSystemNS.PatronWindow and PatronSystemNS.PatronWindow:IsShown() then
+            PatronSystemNS.Logger:UI("Уведомляем PatronWindow о завершении диалога")
+            PatronSystemNS.PatronWindow:OnDialogueEnded()
+        else
+            PatronSystemNS.Logger:UI("PatronWindow не открыт для завершения диалога")
+        end
     end
 end
 


### PR DESCRIPTION
## Summary
- Send dialogue updates to the window of the currently speaking character
- Notify the correct window when a dialogue ends

## Testing
- `luac -p client/core/ui_manager.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed, 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a633170bec8326a19f7154c085ab83