### PR TITLE
Expose speaker info in dialogue events

### DIFF
--- a/client/core/dialogue_engine.lua
+++ b/client/core/dialogue_engine.lua
@@ -164,6 +164,8 @@ function PatronSystemNS.DialogueEngine:OnDialogueReceived(data)
     if PatronSystemNS.UIManager then
         -- БЫЛО: PatronSystemNS.UIManager:UpdateDialogue(data)
         -- СТАЛО: Используем систему событий
+        data.speakerType = self.currentSpeakerType
+        data.speakerId   = self.currentSpeakerID
         PatronSystemNS.UIManager:TriggerEvent("DialogueUpdated", data)
     end
 end


### PR DESCRIPTION
## Summary
- Include current speaker details in `DialogueUpdated` events so the UI knows which window to update

## Testing
- `luac -p client/core/dialogue_engine.lua` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a633e347dc83269375b7c86f1d6c97