### PR TITLE
Cache speaker dialogue data for small talk fallback

### DIFF
--- a/client/ui/follower_window.lua
+++ b/client/ui/follower_window.lua
@@ -301,6 +301,8 @@ end
 function NS.FollowerWindow:UpdateSpeakerData(speakerData)
   NS.Logger:UI("Обновление данных фолловера: " .. (speakerData.Name or "Неизвестно"))
 
+  self.currentSpeakerData = speakerData
+
   local followerID = speakerData.FollowerID or speakerData.SpeakerID
   self.currentFollowerID = followerID or self.currentFollowerID
   if self.currentFollowerID then self.lastFollowerID = self.currentFollowerID end
@@ -384,8 +386,8 @@ function NS.FollowerWindow:OnDialogueEnded()
   self:HideAllReplyButtons()
 
   local text
-  if NS.UIManager and NS.UIManager.currentSpeaker and NS.UIManager.currentSpeaker.smallTalk then
-    text = NS.UIManager.currentSpeaker.smallTalk
+  if self.currentSpeakerData and self.currentSpeakerData.smallTalk then
+    text = self.currentSpeakerData.smallTalk
   else
     text = "Готов к вашим указаниям."
   end

--- a/client/ui/patron_window.lua
+++ b/client/ui/patron_window.lua
@@ -260,6 +260,8 @@ end
 function NS.PatronWindow:UpdateSpeakerData(speakerData)
   NS.Logger:UI("Обновление данных покровителя: " .. (speakerData.Name or "Неизвестно"))
 
+  self.currentSpeakerData = speakerData
+
   local patronID = speakerData.PatronID or speakerData.SpeakerID
   self.currentPatronID = patronID or self.currentPatronID
   if self.currentPatronID then self.lastPatronID = self.currentPatronID end
@@ -345,8 +347,8 @@ function NS.PatronWindow:OnDialogueEnded()
   self:HideAllReplyButtons()
 
   local text
-  if NS.UIManager and NS.UIManager.currentSpeaker and NS.UIManager.currentSpeaker.smallTalk then
-    text = NS.UIManager.currentSpeaker.smallTalk
+  if self.currentSpeakerData and self.currentSpeakerData.smallTalk then
+    text = self.currentSpeakerData.smallTalk
   else
     text = "Выберите действие для взаимодействия с покровителем."
   end


### PR DESCRIPTION
## Summary
- cache speaker data in Patron and Follower windows
- use cached small talk after dialogues end

## Testing
- `luac -p client/ui/patron_window.lua client/ui/follower_window.lua` *(command not found)*
- `apt-get update` *(403 Forbidden errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a63940cb4883268f0ccbe0d7bbbdfc