### PR TITLE
Hide card grid scroll bar until needed

### DIFF
--- a/client/ui/base_window.lua
+++ b/client/ui/base_window.lua
@@ -774,6 +774,7 @@ function NS.BaseWindow.prototype:CreateCardGrid(parent, opts)
   local scroll = CreateFrame("ScrollFrame", self.name.."_CardsScroll", parent, "UIPanelScrollFrameTemplate")
   scroll:SetPoint("TOPLEFT", parent, "TOPLEFT", left, -top)
   scroll:SetPoint("BOTTOMRIGHT", parent, "BOTTOMRIGHT", -right-22, bottom)
+  scroll.ScrollBar:Hide()
 
   local content = CreateFrame("Frame", self.name.."_CardsContent", scroll)
   content:SetSize(1, 1)
@@ -812,6 +813,7 @@ function NS.BaseWindow.prototype:CreateCardGrid(parent, opts)
     local fullH = rowsCount*cellH + (rowsCount-1)*gapY
     local fullW = cols*cellW + (cols-1)*gapX
     self.content:SetSize(fullW, fullH)
+    scroll.ScrollBar:SetShown(content:GetHeight() > scroll:GetHeight())
     return card
   end
 


### PR DESCRIPTION
## Summary
- hide card grid scroll bar on initialization
- show scroll bar only when content exceeds visible area

## Testing
- `lua -v` *(fails: command not found)*
- `apt-get update` *(fails: The repository is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a7815b47108326ba7a0e69e725a588