### PR TITLE
Avoid duplicate category selection

### DIFF
--- a/client/ui/blessing_window.lua
+++ b/client/ui/blessing_window.lua
@@ -65,6 +65,7 @@ NS.BlessingWindow = BW:New("BlessingWindow", {
     end,
 
     onAfterShow = function(self)
+      -- Select the active tab (or default) when the window becomes visible
       self:SelectCategory(self.categoryTabs.getActive() or "Defensive")
     end,
   }
@@ -93,17 +94,16 @@ end
 
 function NS.BlessingWindow:RefreshData()
   print("|cffff0000[DEBUG]|r RefreshData called, currentCategory=" .. tostring(self.currentCategory))
-  
-  -- Перерендериваем текущую категорию с новыми данными
+
+  -- Если категория уже выбрана, просто перерисовываем её
   if self.currentCategory then
-    self:SelectCategory(self.currentCategory)
+    self:RenderCategory(self.currentCategory)
   else
-    print("|cffff0000[DEBUG]|r No currentCategory, selecting default")
-    self:SelectCategory("Defensive")
+    print("|cffff0000[DEBUG]|r No currentCategory set, skipping selection")
   end
-  
+
   -- НЕ перезагружаем состояние панели здесь - это сбрасывает локальные изменения
-  
+
   print("|cffff0000[DEBUG]|r RefreshData completed")
 end
 
@@ -170,7 +170,9 @@ function NS.BlessingWindow:LoadPanelState()
   end
 
   -- Перерисовываем текущую категорию, чтобы обновить сетку
-  self:RenderCategory(self.currentCategory)
+  if self.currentCategory then
+    self:RenderCategory(self.currentCategory)
+  end
 
   print("|cffff0000[PANEL DEBUG]|r LoadPanelState completed")
 end


### PR DESCRIPTION
## Summary
- Render existing category during data refresh without re-selecting it
- Only re-render category after loading panel state when a category is set

## Testing
- `luacheck client/ui/blessing_window.lua` *(fails: command not found)*
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68ab912facc8832688d841abfc769e37