### PR TITLE
Add blessing panel state debug logging

### DIFF
--- a/client/ui/blessing_window.lua
+++ b/client/ui/blessing_window.lua
@@ -133,9 +133,9 @@ function NS.BlessingWindow:DumpBlessingStates()
 
   print("|cffff0000[PANEL DEBUG]|r Dumping blessing states:")
   for blessingId, blessingData in pairs(data.blessings) do
-    local unlocked = blessingData.isDiscovered and "UNLOCKED" or "LOCKED"
-    local inPanel = blessingData.isInPanel and "IN PANEL" or "NOT IN PANEL"
-    print("|cffff0000[PANEL DEBUG]|r Blessing " .. blessingId .. ": " .. unlocked .. ", " .. inPanel)
+    print("|cffff0000[PANEL DEBUG]|r Blessing " .. blessingId ..
+      ": isDiscovered=" .. tostring(blessingData.isDiscovered) ..
+      ", isInPanel=" .. tostring(blessingData.isInPanel))
   end
 end
 

--- a/server/06_PatronSystem_Main.lua
+++ b/server/06_PatronSystem_Main.lua
@@ -244,6 +244,10 @@ local function BuildProgressSnapshot(playerGuid, playerProgress)
                     blessing_type = blessingData.blessing_type,
                     blessing_id = blessingData.blessing_id
                 }
+                PatronLogger:Debug("MainAIO", "BuildProgressSnapshot", "Blessing panel state", {
+                    blessing_id = blessingId,
+                    isInPanel = snapshot.blessings[blessingId].isInPanel
+                })
             end
         end
         


### PR DESCRIPTION
## Summary
- Log each blessing's `isInPanel` flag when building the progress snapshot
- Report `isDiscovered` and `isInPanel` flags in `DumpBlessingStates` for client-side verification

## Testing
- `luac -p server/06_PatronSystem_Main.lua` *(failed: command not found)*
- `luac -p client/ui/blessing_window.lua` *(failed: command not found)*
- `apt-get update` *(failed: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68ab9612ab0c8326a99f88f0bb716e6c