### PR TITLE
Compare blessings by id when removing from slot

### DIFF
--- a/client/ui/blessing_window.lua
+++ b/client/ui/blessing_window.lua
@@ -258,7 +258,7 @@ function NS.BlessingWindow:RemoveBlessingFromSlotSilent(index)
 
     if self.cardGrid and self.cardGrid.cards then
       for _, card in ipairs(self.cardGrid.cards) do
-        if card.__data == blessing then
+        if card.__data and card.__data.id == blessing.id then
           card:Enable()
           if card.__overlay then card.__overlay:Hide() end
           break
@@ -328,7 +328,7 @@ function NS.BlessingWindow:RemoveBlessingFromSlot(index)
 
     if self.cardGrid and self.cardGrid.cards then
       for _, card in ipairs(self.cardGrid.cards) do
-        if card.__data == blessing then
+        if card.__data and card.__data.id == blessing.id then
           card:Enable()
           if card.__overlay then card.__overlay:Hide() end
           break


### PR DESCRIPTION
## Summary
- fix blessing removal to compare cards by blessing id instead of object reference
- ensure matched cards re-enable and hide their overlay when blessing removed

## Testing
- `npm test` *(fails: could not read package.json)*
- `make test` *(fails: No rule to make target 'test')*
- `luacheck client/ui/blessing_window.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aba4675e888326b1010e59ab4c1731