### PR TITLE
Handle cooldown completion for quick blessing buttons

### DIFF
--- a/client/ui/quick_blessing_window.lua
+++ b/client/ui/quick_blessing_window.lua
@@ -209,6 +209,10 @@ function NS.QuickBlessingWindow:CreateBlessingButtons()
         cooldown:SetDrawEdge(false)
         cooldown:SetHideCountdownNumbers(false)
         button.cooldown = cooldown
+        cooldown:SetScript("OnCooldownDone", function()
+            button.cooldown:Clear()
+            button:Enable()
+        end)
 
         -- Настраиваем тултип
         button:SetScript("OnEnter", function(self)


### PR DESCRIPTION
## Summary
- Re-enable quick blessing buttons automatically when their cooldown finishes

## Testing
- `luacheck --version` *(fails: command not found)*
- `lua -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af9a6417c08326931599104e1f05b1