### PR TITLE
Add SafeCall utility

### DIFF
--- a/client/util/safe_call.lua
+++ b/client/util/safe_call.lua
@@ -1,0 +1,26 @@
+local unpack = table.unpack or unpack
+
+local function error_handler(err)
+    local trace = debug.traceback(err, 2)
+    if PatronSystemNS and PatronSystemNS.Logger and PatronSystemNS.Logger.Error then
+        PatronSystemNS.Logger:Error("SafeCall error: " .. tostring(err))
+        PatronSystemNS.Logger:Error(trace)
+    else
+        print("[SafeCall] Error: " .. tostring(err))
+        print(trace)
+    end
+    return err
+end
+
+local function SafeCall(fn, ...)
+    local results = { xpcall(fn, error_handler, ...) }
+    local ok = results[1]
+    if ok then
+        return true, unpack(results, 2)
+    else
+        return false, results[2]
+    end
+end
+
+return SafeCall
+

--- a/server/util/safe_call.lua
+++ b/server/util/safe_call.lua
@@ -1,0 +1,26 @@
+local unpack = table.unpack or unpack
+
+local function error_handler(err)
+    local trace = debug.traceback(err, 2)
+    if PatronLogger and PatronLogger.Error then
+        PatronLogger:Error("SafeCall", "SafeCall", tostring(err))
+        PatronLogger:Error("SafeCall", "StackTrace", trace)
+    else
+        print("[SafeCall] Error: " .. tostring(err))
+        print(trace)
+    end
+    return err
+end
+
+local function SafeCall(fn, ...)
+    local results = { xpcall(fn, error_handler, ...) }
+    local ok = results[1]
+    if ok then
+        return true, unpack(results, 2)
+    else
+        return false, results[2]
+    end
+end
+
+return SafeCall
+


### PR DESCRIPTION
## Summary
- add reusable SafeCall helper on server and client

## Testing
- `luac -p server/util/safe_call.lua` *(fails: command not found)*
- `luac -p client/util/safe_call.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b2364ffd508326bfe5c67c51db8484