### PR TITLE
Expose SafeCall via namespace and adjust initialization

### DIFF
--- a/client/PatronSystem.toc
+++ b/client/PatronSystem.toc
@@ -9,6 +9,7 @@
 
 # Инициализация неймспейса
 init.lua
+util/safe_call.lua
 
 # Конфигурация
 config.lua

--- a/client/core/ui_manager.lua
+++ b/client/core/ui_manager.lua
@@ -3,7 +3,7 @@
   Чистый координатор окон без бизнес-логики + BlessingWindow + ShopWindow
 ============================================================================]]
 
-local SafeCall = require("util.safe_call")
+local SafeCall = PatronSystemNS.SafeCall
 
 -- Заполняем UIManager в уже созданном неймспейсе
 PatronSystemNS.UIManager = {

--- a/client/main.lua
+++ b/client/main.lua
@@ -3,8 +3,12 @@
   Централизованные AIO обработчики + чистая система событий
 ============================================================================]]
 
-local AIO = AIO or require("AIO")
-local SafeCall = require("util.safe_call")
+local AIO = AIO
+local SafeCall = PatronSystemNS.SafeCall
+if not AIO then
+    print("|cffff0000[PatronSystem ERROR]|r AIO library is not available")
+    return
+end
 if AIO.AddAddon() then return end
 
 --[[==========================================================================

--- a/client/util/safe_call.lua
+++ b/client/util/safe_call.lua
@@ -22,5 +22,5 @@ local function SafeCall(fn, ...)
     end
 end
 
-return SafeCall
+PatronSystemNS.SafeCall = SafeCall
 


### PR DESCRIPTION
## Summary
- Expose SafeCall globally via `PatronSystemNS.SafeCall` and load early
- Update UI manager and main initialization to use namespace SafeCall
- Handle missing AIO dependency gracefully

## Testing
- `luac -p client/util/safe_call.lua client/core/ui_manager.lua client/main.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b23e5866b88326896436f5b7758ed9