### PR TITLE
Handle AoE blessing failures

### DIFF
--- a/server/06_PatronSystem_Main.lua
+++ b/server/06_PatronSystem_Main.lua
@@ -1510,8 +1510,8 @@ HandleRequestBlessingCore = function(player, data)
             cooldown_count = cooldownCount
         })
     else
-        player:SendBroadcastMessage("Не удалось применить благословение.")
-        PatronLogger:Error("MainAIO", "HandleRequestBlessing", "Failed to apply blessing effect")
+        SendBlessingError(player, "effect_failed", effectResult and effectResult.message or "Не удалось применить благословение.")
+        PatronLogger:Error("MainAIO", "HandleRequestBlessing", "Failed to apply blessing effect", {reason = effectResult and effectResult.message})
     end
 end
 


### PR DESCRIPTION
## Summary
- make `StartGroundAoE` return success boolean and reason, logging warnings for all early exits
- propagate ground AoE failure through `ApplyBlessingEffect` and respond in `HandleRequestBlessing`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b2413cc9208326bd0c6837955170e6