### PR TITLE
Handle zero budget in StartGroundAoE

### DIFF
--- a/server/05_PatronSystem_GameLogicCore.lua
+++ b/server/05_PatronSystem_GameLogicCore.lua
@@ -981,12 +981,11 @@ if not StartGroundAoE then
 
     -- Рассчитываем базовый урон один раз (как основу для пересчета)
     local singleBase = PatronCalc_SingleBudget(player, info)
+    PatronLogger:Debug("GameLogicCore", "StartGroundAoE", "Computed damage budget", {budget = singleBase})
     if singleBase <= 0 then
-      PatronLogger:Warning("GameLogicCore", "StartGroundAoE", "Zero damage budget")
-      return false, "Zero damage budget"
+      PatronLogger:Warning("GameLogicCore", "StartGroundAoE", "Zero damage budget", {budget = singleBase})
+      return false, "zero_budget"
     end
-
-    print(("[BlessingUI - Server DEBUG] StartGroundAoE: center=(%.1f,%.1f,%.1f) R=%.1f singleBase=%d"):format(cx, cy, cz, radius, singleBase))
 
     -- визуал по земле (мгновенно, без GCD/стоимости)
     if IsValidUnit(player) then

--- a/testing_ground/current_server_solution.lua
+++ b/testing_ground/current_server_solution.lua
@@ -349,8 +349,16 @@ if not StartGroundAoE then
     
     -- Рассчитываем базовый урон один раз (как основу для пересчета)
     local singleBase = PatronCalc_SingleBudget(player, info)
-    if singleBase <= 0 then return end
-    
+    if PatronLogger then
+      PatronLogger:Debug("GameLogicCore", "StartGroundAoE", "Computed damage budget", {budget = singleBase})
+    end
+    if singleBase <= 0 then
+      if PatronLogger then
+        PatronLogger:Warning("GameLogicCore", "StartGroundAoE", "Zero damage budget", {budget = singleBase})
+      end
+      return false, "zero_budget"
+    end
+
     print(("[BlessingUI - Server DEBUG] StartGroundAoE: center=(%.1f,%.1f,%.1f) R=%.1f singleBase=%d"):format(cx, cy, cz, radius, singleBase))
 
     -- визуал по земле (мгновенно, без GCD/стоимости)


### PR DESCRIPTION
## Summary
- log single-target budget for debugging in StartGroundAoE
- treat nonpositive budget as an error and return `false, "zero_budget"`

## Testing
- ⚠️ `luac -p server/05_PatronSystem_GameLogicCore.lua` *(missing Lua compiler)*

------
https://chatgpt.com/codex/tasks/task_e_68b24227067c8326854246aecb17de68