### PR TITLE
Handle dead AoE centers

### DIFF
--- a/server/05_PatronSystem_GameLogicCore.lua
+++ b/server/05_PatronSystem_GameLogicCore.lua
@@ -797,9 +797,10 @@ function clamp(x, lo, hi) return (x<lo and lo) or (x>hi and hi) or x end
 function rand_pm(x) return 1 + (math.random(-x, x) * 0.01) end
 function rand_pm25() return rand_pm(25) end
 
-local function IsValidUnit(u)
-    return u and u.IsInWorld and u:IsInWorld() and u.IsAlive and u:IsAlive()
+local function IsValidUnit(u, allowDead)
+    return u and u.IsInWorld and u:IsInWorld()
            and u.GetTypeId and (u:GetTypeId() == 3 or u:GetTypeId() == 4)
+           and (allowDead or (u.IsAlive and u:IsAlive()))
 end
 
 local function SameMapPhase(a, b)
@@ -956,7 +957,7 @@ end
 -- Точная копия StartGroundAoE из старого файла, но с динамическим расчетом урона
 if not StartGroundAoE then
   function StartGroundAoE(player, centerUnit, info)
-    if not IsValidUnit(player) or not IsValidUnit(centerUnit) then
+    if not IsValidUnit(player) or not IsValidUnit(centerUnit, true) then
       PatronLogger:Warning("GameLogicCore", "StartGroundAoE", "Invalid player or center unit")
       return false, "Invalid player or center unit"
     end


### PR DESCRIPTION
## Summary
- Allow `IsValidUnit` to skip `IsAlive()` when an `allowDead` flag is passed
- Use the new `allowDead` option when validating the AoE center so ground spells can trigger on dead units

## Testing
- `lua -p server/05_PatronSystem_GameLogicCore.lua` *(fails: command not found)*
- `luacheck server/05_PatronSystem_GameLogicCore.lua` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b244b6a78483269e9659c41ffa6246