### PR TITLE
fix: convert follower ids to numbers in quick window

### DIFF
--- a/client/ui/quick_follower_window.lua
+++ b/client/ui/quick_follower_window.lua
@@ -62,10 +62,11 @@ function NS.QuickFollowerWindow:LoadActiveFollowers()
     if not followers then return end
     for id, info in pairs(followers) do
         if info.isDiscovered then
-            local speaker = NS.Config:GetSpeakerByID(id, NS.Config.SpeakerType.FOLLOWER)
+            local idNum = tonumber(id)
+            local speaker = NS.Config:GetSpeakerByID(idNum, NS.Config.SpeakerType.FOLLOWER)
             table.insert(self.followers, {
-                id = tonumber(id),
-                name = (speaker and speaker.name) or ("Follower " .. tostring(id)),
+                id = idNum,
+                name = (speaker and speaker.name) or ("Follower " .. tostring(idNum)),
                 isActive = info.isActive
             })
             if #self.followers >= 3 then break end


### PR DESCRIPTION
## Summary
- convert follower ids to numeric before lookup to ensure proper naming

## Testing
- `luac -p client/ui/quick_follower_window.lua` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68b48710cc1c8326a1011f882629edbb