### PR TITLE
fix: handle numeric string speaker ID

### DIFF
--- a/client/config.lua
+++ b/client/config.lua
@@ -102,6 +102,7 @@ function NS.Config:GetSpeakersByType(speakerType)
 end
 --- Находит говорящего по ID и типу.
 function NS.Config:GetSpeakerByID(speakerID, speakerType)
+    speakerID = tonumber(speakerID)
     for _, s in ipairs(self:GetSpeakersByType(speakerType)) do
         if s.id == speakerID then return s end
     end


### PR DESCRIPTION
## Summary
- allow `GetSpeakerByID` to accept numeric strings

## Testing
- `lua - <<'EOF'
PatronSystemNS = {}
dofile('client/config.lua')
local cfg = PatronSystemNS.Config
print(cfg:GetSpeakerByID(1, cfg.SpeakerType.PATRON).name)
EOF` *(fails: command not found)*
- `apt-get update >/tmp/apt-update.log && tail -n 20 /tmp/apt-update.log` *(fails: 403 Forbidden [IP: 172.30.0.131 8080])*

------
https://chatgpt.com/codex/tasks/task_e_68b487ab8700832681e596e779d33cd5